### PR TITLE
Add hrefs to navbar

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -31,7 +31,7 @@
                 </a>
                 <span class="navbar-item">
                   <a class="button is-primary is-inverted"
-                      href="https://github.com/pangeo-forge/pangeo-forge-recipes/">
+                      href="https://github.com/pangeo-forge">
                     <span class="icon">
                       <i class="mdi mdi-github mdi-24px"></i>
                     </span>

--- a/src/App.vue
+++ b/src/App.vue
@@ -23,7 +23,7 @@
                 <a class="navbar-item" href="https://pangeo-forge.readthedocs.io/en/latest/recipe_box.html">
                   Recipes
                 </a>
-                <a class="navbar-item" href="https://pangeo-forge.org/catalog/">
+                <a class="navbar-item">
                   Catalog
                 </a>
                 <a class="navbar-item" href="https://pangeo-forge.readthedocs.io/en/latest/">

--- a/src/App.vue
+++ b/src/App.vue
@@ -17,20 +17,21 @@
             </div>
             <div id="navbarMenuHeroA" class="navbar-menu">
               <div class="navbar-end">
-                <a class="navbar-item is-active">
+                <a class="navbar-item is-active" href="https://pangeo-forge.org">
                   Home
                 </a>
-                <a class="navbar-item">
+                <a class="navbar-item" href="https://pangeo-forge.readthedocs.io/en/latest/recipe_box.html">
                   Recipes
                 </a>
-                <a class="navbar-item">
+                <a class="navbar-item" href="https://pangeo-forge.org/catalog/">
                   Catalog
                 </a>
-                <a class="navbar-item">
+                <a class="navbar-item" href="https://pangeo-forge.readthedocs.io/en/latest/">
                   Documentation
                 </a>
                 <span class="navbar-item">
-                  <a class="button is-primary is-inverted">
+                  <a class="button is-primary is-inverted"
+                      href="https://github.com/pangeo-forge/pangeo-forge-recipes/">
                     <span class="icon">
                       <i class="mdi mdi-github mdi-24px"></i>
                     </span>


### PR DESCRIPTION
This PR adds hrefs to the navbar, with the exception of the Catalog button, which does not yet have a page to link to.