### PR TITLE
Documentation page outline

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -26,7 +26,7 @@
                 <a class="navbar-item" href="https://pangeo-forge.org/catalog">
                   Catalog
                 </a>
-                <a class="navbar-item" href="https://pangeo-forge.readthedocs.io/en/latest/">
+                <a class="navbar-item" href="https://pangeo-forge.org/docs">
                   Documentation
                 </a>
                 <span class="navbar-item">

--- a/src/components/Documentation.vue
+++ b/src/components/Documentation.vue
@@ -1,0 +1,75 @@
+<template>
+    <section class="section" id="dochome">
+    <div class="columns is-mobile is-centered">
+      <div class="column is-three-quarters-tablet is-half-desktop has-text-centered">
+        <div class="block">
+          <h1 class="title is-1">Documentation</h1>
+          <p>Resources for using Pangeo Forge</p>
+        </div>
+      </div>
+    </div>
+    <div class="content" id="firststeps">
+        <h3 class="title is-3">First steps</h3>
+        <p>New to Pangeo Forge?  Start here!</p>
+        <ul>
+            <li><strong>What is Pangeo Forge?</strong> - Read more about what Pangeo Forge is and
+            how it works.</li>
+            <li><strong>Introduction Tutorial</strong> - Ready to code?  Walk through creating and
+            deploying your first data transformation pipeline.</li>
+        </ul>
+        <hr class="solid">
+    </div>
+    <div class="content" id="organization">
+        <h3 class="title is-3">How the documentation is organized</h3>
+        <p>There are a number of places to access resources when working with components of Pangeo
+        Forge.  Here is an overview of what you will find:</p>
+        <ul>
+            <li>The <strong>Introduction Tutorial</strong> is the place to start with Pangeo Forge.
+            It walks the user through the process of getting setup with their first data transformation.</li>
+            <li><strong>Guides</strong> explain core Pangeo Forge concepts in detail. They provide
+            background information to aid in gaining a depth of understanding.</li>
+            <li><strong>API Reference Pages</strong> are the technical descriptions of the repositories
+            that make up Pangeo Forge. They are useful when you want to review a particular
+            funcationality in depth, but assume you already have a working knowledge of the code base.</li>
+        </ul>
+        <p>While the overview information and intruduction tutorial can be found on the current website,
+        guides and reference pages are locations the documentation pages for theie respective Pangeo 
+        Forge repository.  Links to those pages are listed in the next section.</p>
+        <hr class="solid">
+    </div>
+    <div class="content" id="repositories">
+        <h3 class="title is-3">Repository reference</h3>
+        <p>There are many respositories that make up Pangeo Forge. Here are links to the different
+            documentation pages:</p>
+        <ul>
+            <li><code>pangeo-forge-recipes</code> - Guides | Reference</li>
+            <li><code>pangeo-forge-azure-bakery</code> - Guides | Reference</li>
+            <li><code>pangeo-forge-aws-bakery</code> - Guides | Reference</li>
+        </ul>
+        <hr class="solid">
+    </div>
+    <div class="content" id="community">
+        <h3 class="title is-3">Connecting to the community</h3>
+        <p>Pangeo Forge is a community run effort.  There are roles that people play to support the effort:</p>
+        <ol>
+            <li>recipe contributors — contributors who write recipes to define the data conversions.  This can be anyone with a desire to create analysis ready cloud-optimized (ARCO) data</li>
+            <li>bakery maintainers — contributors who deploy bakeries on cloud infrastructure to process and host the transformed data. This is typically an organization with a grant to fund the infrastructure</li>
+        </ol>
+
+        <p>If you are new to Pangeo Forge and looking to get involved, we suggest getting started with recipe
+        contribution.  You can do in two ways:</p>
+        <ol>
+            <li>Open a ticket with a dataset request (no code required!) - Get started here (link) </li>
+            <li>Write a recipe for a dataset you'd like to see transformed - See recipe creation docs</li>
+        </ol>
+        <h4>Maintainers</h4>
+        <p>Want to help upkeep the Pangeo Forge infrustructure?  See the Contributing docs.</p>
+    </div>
+    </section>
+</template>
+
+<script>
+    export default {
+        name: 'DocHome',
+    }
+</script>

--- a/src/components/Documentation.vue
+++ b/src/components/Documentation.vue
@@ -55,7 +55,11 @@
             <li>recipe contributors — contributors who write recipes to define the data conversions.  This can be anyone with a desire to create analysis ready cloud-optimized (ARCO) data</li>
             <li>bakery maintainers — contributors who deploy bakeries on cloud infrastructure to process and host the transformed data. This is typically an organization with a grant to fund the infrastructure</li>
         </ol>
-
+<blockquote>
+The safety and security of all community members is our top priority.
+Please familiarize yourself with our
+<a href="https://github.com/pangeo-forge/roadmap/blob/master/CODE_OF_CONDUCT.md">Code of Conduct</a>.
+</blockquote>
         <p>If you are new to Pangeo Forge and looking to get involved, we suggest getting started with recipe
         contribution.  You can do in two ways:</p>
         <ol>

--- a/src/components/Documentation.vue
+++ b/src/components/Documentation.vue
@@ -44,7 +44,8 @@
         <ul>
             <li><code>pangeo-forge-recipes</code> - Guides | Reference</li>
             <li><code>pangeo-forge-azure-bakery</code> - Guides | Reference</li>
-            <li><code>pangeo-forge-aws-bakery</code> - Guides | Reference</li>
+            <li><code>staged-recipes</code> - Guides | Reference</li>
+            <li><code>pangeo-forge-catalog</code> - Guides | Reference</li>
         </ul>
         <hr class="solid">
     </div>

--- a/src/components/Documentation.vue
+++ b/src/components/Documentation.vue
@@ -12,48 +12,37 @@
         <h3 class="title is-3">First steps</h3>
         <p>New to Pangeo Forge?  Start here!</p>
         <ul>
-            <li><strong>What is Pangeo Forge?</strong> - Read more about what Pangeo Forge is and
+            <li><strong><a href=https://pangeo-forge.readthedocs.io/en/latest/what_is_pangeo_forge.html>What is Pangeo Forge?</a></strong> - Read more about what Pangeo Forge is and
             how it works.</li>
-            <li><strong>Introduction Tutorial</strong> - Ready to code?  Walk through creating and
-            deploying your first data transformation pipeline.</li>
+            <li><strong><a href=https://github.com/pangeo-forge/roadmap>Pangeo Forge Roadmap</a></strong> - Read more about the origin and direction of Pangeo Forge.</li>
+            <li><strong><a href=https://pangeo-forge.readthedocs.io/en/latest/intro_tutorial.html>Introduction Tutorial</a></strong> - Ready to code?  Walk through creating and
+            deploying your first data transformation.</li>
         </ul>
         <hr class="solid">
     </div>
     <div class="content" id="organization">
         <h3 class="title is-3">How the documentation is organized</h3>
-        <h3 class="title is-3">How the documentation is organized</h3>
-        <p>The <a href="https://pangeo-forge.readthedocs.io/en/latest/">Pangeo Forge Recipes documentation</a>
+        <p>Pangeo Forge is made up of many interdependent repositories, but the 
+            <a href="https://pangeo-forge.readthedocs.io/en/latest/">Pangeo Forge Recipes documentation</a>
             is the primary resource for learning about ecosystem-level concepts.  Here is where you will find 
-            the Introdcution Tutorial or more in depth technical descrdiptions of the Pangeo Forge architecture.</p>
-        <p>Within the ecosystem, Pangeo Forge is made up of many individual repositories. The primary 
-            repositories each have their own set of documentation and are listed in the next section.
-        <p>Generally, each repository documentation page will contain:</p>
-        <ul>
-            <li><strong>Tutorials</strong>: for gettting you started with a particular task or concept</li>
-            <li><strong>Guides</strong>: for explaining core Pangeo Forge concepts in detail. They provide
-            background information to aid in gaining a depth of understanding or step by step
-            instructions for common tasks.</li>
-            <li><strong>API Reference Pages</strong>: the technical descriptions of the repositories
-            that make up Pangeo Forge. They are useful when you want to review a particular
-            funcationality in depth, but they assume you already have a working knowledge of the code base.</li>
-        </ul>
+            the Introduction Tutorial or more in-depth technical descriptions of the Pangeo Forge architecture.
+            This documentation also contains User Guides and Reference Pages for creating recipes.</p>
         <hr class="solid">
     </div>
     <div class="content" id="repositories">
         <h3 class="title is-3">Repository reference</h3>
-        <p>There are many respositories that make up Pangeo Forge. Here are links to several of the primary
-            documentation pages:</p>
+        <p>There are many respositories that make up Pangeo Forge. Here are links to some of the most prominent ones.</p>
         <ul>
-            <li><code>pangeo-forge-recipes</code> - Guides | Reference</li>
-            <li><code>pangeo-forge-azure-bakery</code> - Guides | Reference</li>
-            <li><code>staged-recipes</code> - Guides | Reference</li>
-            <li><code>pangeo-forge-catalog</code> - Guides | Reference</li>
+            <li><code>pangeo-forge-recipes</code> - <a href=https://github.com/pangeo-forge/pangeo-forge-recipes>Repository</a></li>
+            <li><code>pangeo-forge-azure-bakery</code> - <a href=https://github.com/pangeo-forge/pangeo-forge-azure-bakery>Respository</a></li>
+            <li><code>staged-recipes</code> - <a href=https://github.com/pangeo-forge/staged-recipes>Repository</a></li>
+            <li><code>pangeo-forge-catalog</code> - <a href=https://github.com/pangeo-forge/pangeo-forge-catalog>Repository</a></li>
         </ul>
         <hr class="solid">
     </div>
     <div class="content" id="community">
         <h3 class="title is-3">Connecting to the community</h3>
-        <p>Pangeo Forge is a community run effort.  There are roles that people play to support the effort:</p>
+        <p>Pangeo Forge is a community run effort.  There are multiple roles that people play to support the effort:</p>
         <ol>
             <li>recipe contributors — contributors who write recipes to define the data conversions.  This can be anyone with a desire to create analysis ready cloud-optimized (ARCO) data</li>
             <li>bakery maintainers — contributors who deploy bakeries on cloud infrastructure to process and host the transformed data. This is typically an organization with a grant to fund the infrastructure</li>
@@ -69,8 +58,6 @@ Please familiarize yourself with our
             <li>Open a ticket with a dataset request (no code required!) - Get started here (link) </li>
             <li>Write a recipe for a dataset you'd like to see transformed - See recipe creation docs</li>
         </ol>
-        <h4>Maintainers</h4>
-        <p>Want to help upkeep the Pangeo Forge infrustructure?  See the Contributing docs.</p>
     </div>
     </section>
 </template>

--- a/src/components/Documentation.vue
+++ b/src/components/Documentation.vue
@@ -21,25 +21,27 @@
     </div>
     <div class="content" id="organization">
         <h3 class="title is-3">How the documentation is organized</h3>
-        <p>There are a number of places to access resources when working with components of Pangeo
-        Forge.  Here is an overview of what you will find:</p>
+        <h3 class="title is-3">How the documentation is organized</h3>
+        <p>The <a href="https://pangeo-forge.readthedocs.io/en/latest/">Pangeo Forge Recipes documentation</a>
+            is the primary resource for learning about ecosystem-level concepts.  Here is where you will find 
+            the Introdcution Tutorial or more in depth technical descrdiptions of the Pangeo Forge architecture.</p>
+        <p>Within the ecosystem, Pangeo Forge is made up of many individual repositories. The primary 
+            repositories each have their own set of documentation and are listed in the next section.
+        <p>Generally, each repository documentation page will contain:</p>
         <ul>
-            <li>The <strong>Introduction Tutorial</strong> is the place to start with Pangeo Forge.
-            It walks the user through the process of getting setup with their first data transformation.</li>
-            <li><strong>Guides</strong> explain core Pangeo Forge concepts in detail. They provide
-            background information to aid in gaining a depth of understanding.</li>
-            <li><strong>API Reference Pages</strong> are the technical descriptions of the repositories
+            <li><strong>Tutorials</strong>: for gettting you started with a particular task or concept</li>
+            <li><strong>Guides</strong>: for explaining core Pangeo Forge concepts in detail. They provide
+            background information to aid in gaining a depth of understanding or step by step
+            instructions for common tasks.</li>
+            <li><strong>API Reference Pages</strong>: the technical descriptions of the repositories
             that make up Pangeo Forge. They are useful when you want to review a particular
-            funcationality in depth, but assume you already have a working knowledge of the code base.</li>
+            funcationality in depth, but they assume you already have a working knowledge of the code base.</li>
         </ul>
-        <p>While the overview information and intruduction tutorial can be found on the current website,
-        guides and reference pages are locations the documentation pages for theie respective Pangeo 
-        Forge repository.  Links to those pages are listed in the next section.</p>
         <hr class="solid">
     </div>
     <div class="content" id="repositories">
         <h3 class="title is-3">Repository reference</h3>
-        <p>There are many respositories that make up Pangeo Forge. Here are links to the different
+        <p>There are many respositories that make up Pangeo Forge. Here are links to several of the primary
             documentation pages:</p>
         <ul>
             <li><code>pangeo-forge-recipes</code> - Guides | Reference</li>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -2,6 +2,7 @@ import Vue from 'vue'
 import VueRouter from 'vue-router'
 import Home from '../components/Home.vue'
 import Browse from '../components/Browse.vue'
+import Documentation from '../components/Documentation.vue'
 // import NotFound from '../components/NotFound.vue'
 
 Vue.use(VueRouter)
@@ -14,7 +15,11 @@ const routes = [
   {
       path: '/catalog',
       component: Browse
-  }/*,
+  },
+  {
+    path: '/docs',
+    component: Documentation
+  },/*,
   {
     path: '*',
     component: NotFound


### PR DESCRIPTION
## What has been built?
This PR provides a potential outline for a central documentation page for Pangeo Forge, as discussed in [Issue #25](https://github.com/pangeo-forge/roadmap/issues/25). 

Most parts of this page haven't been developed yet so we probably don't want to actually merge all of these suggestions, but I hope that what is in this PR could provide an outline for what we want the centralized docs page to become.  As always I'm very open to feedback.

## How was it done?
@cisaacstern has already typed out the steps:
1. Add the page itself as a file called `Documention.vue` to `src/components/`
2. Add a reference to it in `src/router/index.js`
2. Change the Documentation href in `src/App.vue`

Note that because the link in the "Documentation" button is hardcoded you have to manually navigate to `localhost:8080/docs` to see the new page.